### PR TITLE
fix: validate duration

### DIFF
--- a/alerterator.go
+++ b/alerterator.go
@@ -73,6 +73,11 @@ func (n *Alerterator) synchronize(previous, alert *v1alpha1.Alert) error {
 	// Alerts are cluster-wide, so we just add the 'default'-namespace as an easy fix
 	alert.Namespace = "default"
 
+	err = alert.ValidateAlertFields()
+	if err != nil {
+		return fmt.Errorf("while validating alert fields: %s", err)
+	}
+
 	err = api.UpdateAlertManagerConfigMap(n.ClientSet.CoreV1().ConfigMaps(configMapNamespace), alert)
 	if err != nil {
 		return fmt.Errorf("while updating AlertManager.yml configMap: %s", err)

--- a/api/updater/receivers.go
+++ b/api/updater/receivers.go
@@ -104,7 +104,9 @@ func DeleteReceiver(alert *v1alpha1.Alert, alertManager map[interface{}]interfac
 	}
 
 	index := getReceiverIndexByName(alert.Name, receivers)
-	receivers = append(receivers[:index], receivers[index+1:]...)
+	if index != -1 {
+		receivers = append(receivers[:index], receivers[index+1:]...)
+	}
 	alertManager["receivers"] = receivers
 
 	return nil

--- a/example/max_alerts.yaml
+++ b/example/max_alerts.yaml
@@ -21,7 +21,7 @@ spec:
       action: kubectl describe pod -l app=nais-testapp
       documentation: https://github.com/navikt/aura-doc/naisvakt/alerts.md#app_unavailable
       sla: respond within 1h, during office hours
-      severity: critical
+      severity: danger
     - alert: CoreDNS unavailable
       description: CoreDNS unavailable, there are zero replicas
       expr: 'kube_deployment_status_replicas_available{namespace="kube-system", deployment="coredns"} == 0'
@@ -29,4 +29,4 @@ spec:
       action: kubectl describe pod -l app=nais-testapp
       documentation: https://github.com/navikt/aura-doc/naisvakt/alerts.md#coredns
       sla: respond within 1h, solve within 4h, around the clock
-      severity: critical
+      severity: danger

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/nais/alerterator
 
 require (
 	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.16.0 // indirect
 	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
@@ -12,6 +14,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/json-iterator/go v1.1.5 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -20,11 +23,11 @@ require (
 	github.com/prometheus/client_golang v0.9.2
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/pflag v1.0.3 // indirect
-	github.com/stretchr/testify v1.3.0
-	golang.org/x/crypto v0.0.0-20190128193316-c7b33c32a30b // indirect
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c // indirect
-	golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc // indirect
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
+	golang.org/x/tools v0.0.0-20191024074452-7defa796fec0 // indirect
+	gopkg.in/go-playground/validator.v9 v9.30.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20181128191700-6db15a15d2d3 // kubernetes-1.12.5
@@ -32,3 +35,5 @@ require (
 	k8s.io/client-go v9.0.0+incompatible
 	k8s.io/kube-openapi v0.0.0-20190202092118-df6fb93e6113 // indirect
 )
+
+go 1.13

--- a/pkg/apis/alerterator/v1alpha1/alert.yaml
+++ b/pkg/apis/alerterator/v1alpha1/alert.yaml
@@ -40,6 +40,9 @@ spec:
           properties:
             receivers:
               type: object
+              required:
+                - slack
+                - email
               properties:
                 slack:
                   type: object
@@ -62,22 +65,24 @@ spec:
                 - for
                 - expr
                 - action
-              properties:
-                alert:
-                  type: string
-                description:
-                  type: string
-                expr:
-                  type: string
-                for:
-                  type: string
-                  pattern: '\d+[mh]'
-                action:
-                  type: string
-                documentation:
-                  type: string
-                sla:
-                  type: string
-                severity:
-                  type: string
-                  pattern: 'good|warning|danger|#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})'
+              items:
+                type: object
+                properties:
+                  alert:
+                    type: string
+                  description:
+                    type: string
+                  expr:
+                    type: string
+                  for:
+                    type: string
+                    pattern: '^\d+[smhdwy]$'
+                  action:
+                    type: string
+                  documentation:
+                    type: string
+                  sla:
+                    type: string
+                  severity:
+                    type: string
+                    pattern: 'good|warning|danger|#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})'

--- a/pkg/apis/alerterator/v1alpha1/alert.yaml
+++ b/pkg/apis/alerterator/v1alpha1/alert.yaml
@@ -40,9 +40,6 @@ spec:
           properties:
             receivers:
               type: object
-              required:
-                - slack
-                - email
               properties:
                 slack:
                   type: object

--- a/pkg/apis/alerterator/v1alpha1/types_test.go
+++ b/pkg/apis/alerterator/v1alpha1/types_test.go
@@ -25,3 +25,32 @@ func TestNilFix(t *testing.T) {
 	assert.NotNil(t, alert.Spec.Receivers)
 	assert.NotNil(t, alert.Spec.Alerts)
 }
+
+func TestAlertRulesValidationWithEmptyForValue(t *testing.T) {
+	alert := GenerateAlertWithForValue("")
+	err := alert.ValidateAlertFields()
+	assert.Error(t, err)
+}
+
+func TestAlertRulesValidationWithValidForValue(t *testing.T) {
+	alert := GenerateAlertWithForValue("1m")
+	err := alert.ValidateAlertFields()
+	assert.NoError(t, err)
+}
+
+func TestAlertRulersValidationWithInvalidForValue(t *testing.T) {
+	alert := GenerateAlertWithForValue("foo")
+	err := alert.ValidateAlertFields()
+	assert.Error(t, err)
+}
+
+func GenerateAlertWithForValue(forValue string) v1alpha1.Alert {
+	return v1alpha1.Alert{Spec: v1alpha1.AlertSpec{Alerts: []v1alpha1.Rule{
+		{
+			Alert:  "app is down",
+			For:    forValue,
+			Expr:   "kube_deployment_status_replicas_unavailable{deployment=\"my-app\"} > 0",
+			Action: "kubectl describe pod -l app=my-app",
+		},
+	}}}
+}


### PR DESCRIPTION
Fixes #11.

(this is my first foray into Go in general so bear with me)

Initially started looking at validating the alertrules to handle already applied `Alert` resources to prevent them from being added to the alertmanager configmap. 

Then I found out that CRDs have structural schemas for validation, which in this case did not validate any alert due to a syntax error - which I believe I've now fixed. As a result, the alertrule validation might be somewhat unnecessary (though I've chosen to include it here anyway).