### PR TITLE
fix: allow empty or omitted value for `spec.alerts.severity`

### DIFF
--- a/pkg/apis/alerterator/v1alpha1/alert.yaml
+++ b/pkg/apis/alerterator/v1alpha1/alert.yaml
@@ -82,4 +82,4 @@ spec:
                     type: string
                   severity:
                     type: string
-                    pattern: 'good|warning|danger|#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})'
+                    pattern: '^$|good|warning|danger|#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})'


### PR DESCRIPTION
Fixes #18. This will default to 'danger' if not set anyway.